### PR TITLE
remove :wellform option

### DIFF
--- a/lib/lcsort.rb
+++ b/lib/lcsort.rb
@@ -56,35 +56,22 @@ class Lcsort
 
   def self.normalize(cn, opts = {})
     callnum = cn.upcase.gsub(/^[^A-Z0-9]*|[^A-Z0-9]*$/, '')
-    if match = LC.match(callnum)
-      alpha, num, dec, c1alpha, c1num, c2alpha, c2num, c3alpha, c3num, extra = match.captures
-      origs = match.captures
-    else
-      if opts[:wellform]
-        puts callnum
-        return nil
-      else
-        return callnum
-      end
+    
+    match = LC.match(callnum)
+    unless match
+      return nil
     end
 
+    alpha, num, dec, c1alpha, c1num, c2alpha, c2num, c3alpha, c3num, extra = match.captures
+    origs = match.captures
+    
     if dec.to_s.length > 6
-      if opts[:wellform]
-        puts callnum
-        return nil
-      else
-        return callnum
-      end
+      return nil
     end
 
     if !alpha.nil? && !(!num.nil? || !dec.nil? || !c1alpha.nil? || !c1num.nil? || !c2alpha.nil? || !c2num.nil? || !c3alpha.nil? || !c3num.nil?)
       if !extra.nil?
-        if opts[:wellform]
-          puts callnum
-          return nil
-        else
-          return callnum
-        end
+        return nil
       end
       if opts[:bottomout]
         return alpha + BOTTOMSPACE * (3 - alpha.length)

--- a/test/test_lcsort.rb
+++ b/test/test_lcsort.rb
@@ -18,7 +18,7 @@ class LcsortTest < Minitest::Test
     'D  0015400000D220 000 000 1990',
     'E  0008000000C110D220',
     'ZA 4082000000G330M434D540 1998',
-    'MICROFILM'
+    nil
   ]
 
   EXPECTED_ENDRANGE = ['A  0001999999~999~999~999',
@@ -27,7 +27,7 @@ class LcsortTest < Minitest::Test
     'D  0015400000D220 000 000 1990',
     'E  0008000000C110D229~999',
     'ZA 4082000000G330M434D540 1998',
-    'MICROFILM'
+    nil
   ]
 
   EXPECTED_WELLFORM = ['A  0001',
@@ -63,8 +63,13 @@ class LcsortTest < Minitest::Test
 
   def test_wellform
     TEST_CALLNOS.each_with_index do |callno, i|
-      assert_equal EXPECTED_WELLFORM[i], Lcsort.normalize(callno, :wellform => true)
+      assert_equal EXPECTED_WELLFORM[i], Lcsort.normalize(callno)
     end
+  end
+
+  def test_bad_callnums
+    assert_nil Lcsort.normalize("this is not a call number")
+    assert_nil Lcsort.normalize("12234")
   end
 
   def equal_strip


### PR DESCRIPTION
Will always behave as if previous :wellform => true now.

Makes the source code much simpler and easier to read.

The :wellform option is unneccesary, if you wanted the equivalent
of the previous :wellform => false (previously default, now
unavailable), you can do along these lines:

  x  = Lcsort.normalize(callno) || callno.upcase
