### PR TITLE
test dates in cutter position

### DIFF
--- a/test/test_lcsort.rb
+++ b/test/test_lcsort.rb
@@ -72,6 +72,14 @@ class LcsortTest < Minitest::Test
     assert_nil Lcsort.normalize("12234")
   end
 
+  def test_parses_weird_numbers
+    # These may NOT be currently sorted correctly, but they parse somehow,
+    # and we want to at least keep it that way, I think.     
+    refute_nil Lcsort.normalize("A1.2 .A54 21st 2010")
+    refute_nil Lcsort.normalize("KF 4558 15th .G8")
+    refute_nil Lcsort.normalize("JX 45.5 2nd .A54 .G888 2010")
+  end
+
   def equal_strip
     TEST_LEADING_TRAILING.each_with_index do |callno, i|
       assert_equal Lcsort.normalize(EXPECTED_REGULAR[i]), Lcsort.normalize(callno)

--- a/test/test_sort_orders.rb
+++ b/test/test_sort_orders.rb
@@ -156,6 +156,32 @@ class TestSortOrders < Minitest::Test
     ])
   end
 
+  # LC call numbers can have a 'date or other number', usually
+  # a year, in a cutter position, most commonly first. 
+  #
+  # These currently sort correctly more or less accidentally --
+  # they are not parsed correctly, everything including and after
+  # the year ends up in 'extra', but they sort correctly ANYWAY. 
+  #
+  # We have a test to make sure it stays that way. 
+  def test_year_cutter
+    list = [
+            "PX 101.1",
+            "PX 101.1 1989",
+            "PX 101.1 1990",
+            "PX 101.1 1990 .A3",
+            "PX 101.1 1990 .A34",
+            "PX 101.1 1990 .A34 .B55",
+            "PX 101.1 1990 .A34 .B6",
+            "PX 101.1 1990 .A5",
+            "PX 101.1 1992",
+            "PX 101.1 2012",
+            "PX 101.1 .A5"
+           ]
+
+    assert_sorted_order list
+  end
+
 
   def assert_sorted_order(array)
     assert_equal array, array.shuffle.sort_by {|call_num| Lcsort.normalize(call_num)}


### PR DESCRIPTION
Some types actually sort correctly currently, more or less
accidentally. Other types do not sort correctly, but parse
and sort kind of okayish. Tests to help us make sure it stays
at least this good.
