### PR TITLE
ignore cutter prefix, move cutter suffix to extra

### DIFF
--- a/lib/lcsort.rb
+++ b/lib/lcsort.rb
@@ -22,23 +22,23 @@ class Lcsort
       \s*
       (?:               # optional cutter
         \.? \s*
-        ([A-Z])      # cutter letter  c1alpha
+        ([a-z]?[A-Z])      # cutter letter  c1alpha
         \s*
-        (\d+ | \Z)        # cutter numbers  c1num
+        (\d{1,6}[a-z]{0,2} | \Z)        # cutter numbers  c1num
       )?
       \s*
       (?:               # optional cutter
         \.? \s*
-        ([A-Z])      # cutter letter  c2alpha
+        ([a-z]?[A-Z])      # cutter letter  c2alpha
         \s*
-        (\d+ | \Z)        # cutter numbers  c2num
+        (\d{1,6}[a-z]{0,2} | \Z)        # cutter numbers  c2num
       )?
       \s*
       (?:               # optional cutter
         \.? \s*
-        ([A-Z])      # cutter letter  c3alpha
+        ([a-z]?[A-Z])      # cutter letter  c3alpha
         \s*
-        (\d+ | \Z)        # cutter numbers  c3num
+        (\d{1,6}[a-z]{0,2} | \Z)        # cutter numbers  c3num
       )?
       (\s+.+?)?        # everthing else extra
       \s*$/x
@@ -55,7 +55,7 @@ class Lcsort
   end
 
   def self.normalize(cn, opts = {})
-    callnum = cn.upcase.gsub(/^[^A-Z0-9]*|[^A-Z0-9]*$/, '')
+    callnum = cn[0][/[a-z]/].nil? ? cn : cn.upcase
     
     match = LC.match(callnum)
     unless match
@@ -65,7 +65,7 @@ class Lcsort
     alpha, num, dec, c1alpha, c1num, c2alpha, c2num, c3alpha, c3num, extra = match.captures
     origs = match.captures
     
-    if dec.to_s.length > 6
+    if dec.to_s.length > 6 || num.to_s.length > 4
       return nil
     end
 
@@ -78,25 +78,33 @@ class Lcsort
       end
       return alpha
     end
-    enorm = extra.to_s.gsub(/[^A-Z0-9]/, '')
+
+    c1alpha.gsub!(/[a-z]/, '') unless c1alpha.nil?
+    c2alpha.gsub!(/[a-z]/, '') unless c2alpha.nil?
+    c3alpha.gsub!(/[a-z]/, '') unless c3alpha.nil?
+
+    c1num.gsub!(/[a-z]{1,2}/) {|m| extra = extra.to_s + m; m=''} unless c1num.nil?
+    c2num.gsub!(/[a-z]{1,2}/) {|m| extra = extra.to_s + m; m=''} unless c2num.nil?
+    c3num.gsub!(/[a-z]{1,2}/) {|m| extra = extra.to_s + m; m=''} unless c3num.nil?
+
+    enorm = extra.to_s.upcase.gsub(/[^A-Z0-9]/, '')
     num = '%04d' % num.to_s.to_i
 
     c1a = c1alpha.nil? ? TOPSPACE : c1alpha
     c2a = c2alpha.nil? ? TOPSPACE : c2alpha
     c3a = c3alpha.nil? ? TOPSPACE : c3alpha
 
-
     topnorm = [
       alpha.to_s + TOPSPACE * filler(3, alpha),
       num.to_s + TOPDIGIT * filler(4, num),
       dec.to_s + TOPDIGIT * filler(6, dec),
       c1a,
-      c1num.to_s + TOPDIGIT * filler(3, c1num),
+      c1num.to_s + TOPDIGIT * filler(6, c1num),
       c2a,
-      c2num.to_s + TOPDIGIT * filler(3, c2num),
+      c2num.to_s + TOPDIGIT * filler(6, c2num),
       c3a,
-      c3num.to_s + TOPDIGIT * filler(3, c3num),
-      ' ' + enorm,
+      c3num.to_s + TOPDIGIT * filler(6, c3num),
+      ' ' + enorm
     ]
 
     if !extra.nil?
@@ -105,18 +113,18 @@ class Lcsort
 
     c1al = c1alpha.nil? ? BOTTOMSPACE : c1alpha
     c2al = c2alpha.nil? ? BOTTOMSPACE : c2alpha
-    c3al = c3alpha.nil? ? BOTTOMSPACE : c3alpha 
+    c3al = c3alpha.nil? ? BOTTOMSPACE : c3alpha
 
     bottomnorm = [
       alpha.to_s + BOTTOMSPACE * filler(3, alpha),
       num.to_s + BOTTOMDIGIT * filler(4, num),
       dec.to_s + BOTTOMDIGIT * filler(6, dec),
       c1al,
-      c1num.to_s + BOTTOMDIGIT * filler(3, c1num),
+      c1num.to_s + BOTTOMDIGIT * filler(6, c1num),
       c2al,
-      c2num.to_s + BOTTOMDIGIT * filler(3, c2num),
+      c2num.to_s + BOTTOMDIGIT * filler(6, c2num),
       c3al,
-      c3num.to_s + BOTTOMDIGIT * filler(3, c3num)
+      c3num.to_s + BOTTOMDIGIT * filler(6, c3num)
     ]
 
 

--- a/test/test_lcsort.rb
+++ b/test/test_lcsort.rb
@@ -14,39 +14,20 @@ class LcsortTest < Minitest::Test
 
   EXPECTED_NORM = ['A  0001',
     'B  0022300000',
-    'C  0001000000D110',
-    'D  0015400000D220 000 000 1990',
-    'E  0008000000C110D220',
-    'ZA 4082000000G330M434D540 1998',
+    'C  0001000000D110000',
+    'D  0015400000D220000 000000 000000 1990',
+    'E  0008000000C110000D220000',
+    'ZA 4082000000G330000M434000D540000 1998',
     nil
   ]
 
-  EXPECTED_ENDRANGE = ['A  0001999999~999~999~999',
-    'B  0022399999~999~999~999',
-    'C  0001000000D119~999~999',
-    'D  0015400000D220 000 000 1990',
-    'E  0008000000C110D229~999',
-    'ZA 4082000000G330M434D540 1998',
+  EXPECTED_ENDRANGE = ['A  0001999999~999999~999999~999999',
+    'B  0022399999~999999~999999~999999',
+    'C  0001000000D119999~999999~999999',
+    'D  0015400000D220000 000000 000000 1990',
+    'E  0008000000C110000D229999~999999',
+    'ZA 4082000000G330000M434000D540000 1998',
     nil
-  ]
-
-  EXPECTED_WELLFORM = ['A  0001',
-    'B  0022300000',
-    'C  0001000000D110',
-    'D  0015400000D220 000 000 1990',
-    'E  0008000000C110D220',
-    'ZA 4082000000G330M434D540 1998',
-    nil
-  ]
-
-  TEST_LEADING_TRAILING = ['.A20',
-    'B31.4 1992.',
-    'Microfilm.'
-  ]
-
-  EXPECTED_REGULAR = ['A20',
-    'B31.4 1992',
-    'MICROFILM'
   ]
 
   def test_normalization
@@ -61,12 +42,6 @@ class LcsortTest < Minitest::Test
     end
   end
 
-  def test_wellform
-    TEST_CALLNOS.each_with_index do |callno, i|
-      assert_equal EXPECTED_WELLFORM[i], Lcsort.normalize(callno)
-    end
-  end
-
   def test_bad_callnums
     assert_nil Lcsort.normalize("this is not a call number")
     assert_nil Lcsort.normalize("12234")
@@ -78,12 +53,6 @@ class LcsortTest < Minitest::Test
     refute_nil Lcsort.normalize("A1.2 .A54 21st 2010")
     refute_nil Lcsort.normalize("KF 4558 15th .G8")
     refute_nil Lcsort.normalize("JX 45.5 2nd .A54 .G888 2010")
-  end
-
-  def equal_strip
-    TEST_LEADING_TRAILING.each_with_index do |callno, i|
-      assert_equal Lcsort.normalize(EXPECTED_REGULAR[i]), Lcsort.normalize(callno)
-    end
   end
 
 end

--- a/test/test_sort_orders.rb
+++ b/test/test_sort_orders.rb
@@ -156,6 +156,22 @@ class TestSortOrders < Minitest::Test
     ])
   end
 
+  def test_with_cutter_suffixes
+    assert_sorted_order([
+      "QA 101.1 A101",
+      "QA 101.1 A101a",
+      "QA 101.1 A101b",
+      "QA 101.1 A101 B101"
+    ])
+
+    assert_sorted_order([
+      "QA 101.1 A101 B101",
+      "QA 101.1 A101 B101 1999",
+      "QA 101.1 A101a B101",
+      "QA 101.1 A101b B101"
+    ])
+  end
+
   # LC call numbers can have a 'date or other number', usually
   # a year, in a cutter position, most commonly first. 
   #
@@ -182,6 +198,16 @@ class TestSortOrders < Minitest::Test
     assert_sorted_order list
   end
 
+
+  def x_prefix
+    assert_sorted_order([
+      "BP190.5.W34 K437 1993",
+      "BP190.5.W35 A22 2000",
+      "BP190.5.W35 xA22 2001",
+      "BP190.5.W35 A222 1990",
+      "BP190.5.W35 xF3"
+    ])
+  end
 
   def assert_sorted_order(array)
     assert_equal array, array.shuffle.sort_by {|call_num| Lcsort.normalize(call_num)}


### PR DESCRIPTION
Check out these changes @jrochkind
- Treat cutter decimal numbers like the first decimal - support up to 6 digits
- Since lowercase characters carry value in determining the sort, only upcase the whole call number if the first character is lowercase. This allows the regex to detect whether there are prefixes/suffixes attached to cutters.
  - We have lowercase 'x' prefixes that we need to ignore that sometimes appear directly before a cutter, ie: `BP190.5.W35 xF3`
  - Detects optional suffixes and appends them to the extra. Whenever the normalizer detects that there is an extra value associated with the call number, it pads the call number's blank cutters with spaces and 0s before adding the extra. 
- Reject call number if first num is more than 4 digits before decimal
