### PR TITLE
revert remove bad leading/trailing eb0dcb

### DIFF
--- a/lib/lcsort.rb
+++ b/lib/lcsort.rb
@@ -55,7 +55,7 @@ class Lcsort
   end
 
   def self.normalize(cn, opts = {})
-    callnum = cn.upcase.gsub(/^[^A-Z0-9]*|[^A-Z0-9]*$/, '')
+    callnum = cn.upcase
     
     match = LC.match(callnum)
     unless match

--- a/test/test_lcsort.rb
+++ b/test/test_lcsort.rb
@@ -39,16 +39,6 @@ class LcsortTest < Minitest::Test
     nil
   ]
 
-  TEST_LEADING_TRAILING = ['.A20',
-    'B31.4 1992.',
-    'Microfilm.'
-  ]
-
-  EXPECTED_REGULAR = ['A20',
-    'B31.4 1992',
-    'MICROFILM'
-  ]
-
   def test_normalization
     TEST_CALLNOS.each_with_index do |callno, i|
       assert_equal EXPECTED_NORM[i], Lcsort.normalize(callno)
@@ -78,12 +68,6 @@ class LcsortTest < Minitest::Test
     refute_nil Lcsort.normalize("A1.2 .A54 21st 2010")
     refute_nil Lcsort.normalize("KF 4558 15th .G8")
     refute_nil Lcsort.normalize("JX 45.5 2nd .A54 .G888 2010")
-  end
-
-  def equal_strip
-    TEST_LEADING_TRAILING.each_with_index do |callno, i|
-      assert_equal Lcsort.normalize(EXPECTED_REGULAR[i]), Lcsort.normalize(callno)
-    end
   end
 
 end


### PR DESCRIPTION
This normalization was actually causing problems for me,
accepting bad LC's I want it to reject. Local consumer
can easily do this on it's own before passing to Lcsort, if
desired.

Note: Your tests weren't actually doing anything, tests still
passed after I removed the functionality! You forgot to begin
your test method with `test_`, so it wasn't being called. Be
careful with this -- it can often be good to make sure your
tests for new functionality really do fail before the new func
is added! But I've removed the attempt at a test that wasn't
being executed too.
